### PR TITLE
uses sourceDistribution instead of sourceArtifactory

### DIFF
--- a/pipelines.yml
+++ b/pipelines.yml
@@ -48,21 +48,21 @@ resources:
   - name: releaseBundle
     type: ReleaseBundle
     configuration:
-      sourceArtifactory: art
+      sourceDistribution: dist
       name: swampup
       version: v1.0.0
 
   - name: signedBundle
     type: ReleaseBundle
     configuration:
-      sourceArtifactory: art
+      sourceDistribution: dist
       name: swampup
       version: v1.0.0
 
   - name: distributionRules
     type: DistributionRule
     configuration:
-      sourceArtifactory: art
+      sourceDistribution: dist
       serviceName: "*"
       siteName: "*"
       cityName: "*"


### PR DESCRIPTION
Updates the demo for the changes done as part of https://github.com/Shippable/heap/issues/3458

