### PR TITLE
uses GB country code in DistributionRule

### DIFF
--- a/pipelines.yml
+++ b/pipelines.yml
@@ -68,7 +68,7 @@ resources:
       cityName: "*"
       countryCodes:
         - "CN"
-        - "EU"
+        - "GB"
 
   - name: deploy_vm
     type: VmCluster


### PR DESCRIPTION
Addresses https://github.com/Shippable/heap/issues/3476

Verified by running a sample Distribute step as part of a pipeline in my project.

![image](https://user-images.githubusercontent.com/4211715/60428770-40fcc900-9c17-11e9-8b45-f7bb4ede17fb.png)



